### PR TITLE
GGC - Modified Syringe.fpe to use healthboost.lua

### DIFF
--- a/GameGuru Core/GameGuru/Files/entitybank/Collectables/Syringe.fpe
+++ b/GameGuru Core/GameGuru/Files/entitybank/Collectables/Syringe.fpe
@@ -1,0 +1,47 @@
+;header
+desc          = Syringe
+
+;identity details
+isweapon      = 0
+isammo	      = 0
+ishealth      = 1
+isimmobile    = 1
+
+;ai
+aiinit	      =
+aimain	      = healthboost.lua
+aidestroy     =
+
+;Sound
+soundset      = audiobank\misc\health.wav
+
+;specific data
+quantity      = 50
+
+;visualinfo
+textured      = syringe_D.dds
+effect        = effectbank\reloaded\entity_basic.fx
+castshadow    = 0
+
+;orientation
+model         = syringe.x
+offx          = 0
+offy          = 0
+offz          = 0
+rotx          = 0
+roty          = 0
+rotz          = 0
+defaultstatic = 0
+materialindex = 3
+
+;statistics
+strength      = 25
+explodable    = 0
+debrisshape   = 1
+
+;spawn
+spawnmax      = 0
+spawndelay    = 0
+spawnqty      = 0
+
+


### PR DESCRIPTION
The Syringe Item will now make use of the new healthboost.lua script health boost (which was added some versions ago) which will increase the players health beyond that of the maximum.

Previously recovery, healing, health items would increase the health of the player exceeding the maximum health value. Which would go against recovery and healing methods and instead act as a boost or buff. We had since removed that and made them as healing items. Due to that, we dont have any items that act as boosts or buffs, so I've included the healthboost script to the syringe so it can operate as a health boost (and actually operate as original health did in early versions of GGC).

