### PR TITLE
GGC - Improved Collectable Keys

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/key.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/key.lua
@@ -1,12 +1,20 @@
 -- LUA Script - precede every function and global member with lowercase name of script + '_main'
 -- Player Collects Key
 
+keyname = {}
+
 function key_init(e)
+end
+
+function key_init_name(e, name)
+keyname[e] = name
 end
 
 function key_main(e)
  PlayerDist = GetPlayerDistance(e)
- if PlayerDist < 150 and g_PlayerHealth > 0 then
+ 
+ -- If in first person collect key only if within 150 distance from the player and if the player is looking in the direction of the key
+ if PlayerDist < 150 and g_PlayerHealth > 0 and g_PlayerThirdPerson == 0 then
 	SourceAngle = g_PlayerAngY
 	while SourceAngle < 0.0 do
 		SourceAngle = SourceAngle + 360.0
@@ -29,12 +37,12 @@ function key_main(e)
 	if Result < 20.0 then
 		if IntersectStatic(g_PlayerPosX,g_PlayerPosY+50,g_PlayerPosZ,g_Entity[e]['x'],g_Entity[e]['y'],g_Entity[e]['z'],g_Entity[e]['obj']) == 0 then
 			if GetGamePlayerStateXBOX() == 1 then
-			 Prompt("Press Y button to pick up key")
+			 Prompt("Press Y button to pick up "..keyname[e])
 			else
-			 Prompt("Press E to pick up key")
+			 Prompt("Press E to pick up "..keyname[e])
 			end
 			if g_KeyPressE == 1 then
-				Prompt("Collected key")
+				Prompt("Collected "..keyname[e])
 				PlaySound(e,0)
 				Collected(e)
 				Destroy(e)
@@ -43,4 +51,15 @@ function key_main(e)
 		end
    end
  end
+ 
+	-- If third person then automatically collect key when near
+	if PlayerDist < 80 and g_PlayerHealth > 0 and g_PlayerThirdPerson > 0 then
+ 				Prompt("Collected "..keyname[e])
+				PlaySound(e,0)
+				Collected(e)
+				Destroy(e)
+				ActivateIfUsed(e)
+	end
+ 
+ 
 end


### PR DESCRIPTION
Collecting keys will now display the name of the key entity, thus allowing users to name their keys. For Example "Collected key" can now be "Collected Card 1" or "Collected Iron Key" etc. Whatever you name the key in the entity properties will be displayed when attempting to pick up a key and when the key has been collected.

Additionally, the key will automatically be collected in 3rd person if the player is within 80 units of the key, avoiding any issues people have raised related to collection distance and perspective issues with unique 3rd person player character models.