### PR TITLE
GGC - Playable Map Area To Use Variables

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
@@ -896,10 +896,12 @@ function gameplayercontrol.control()
 	end
 
 	-- Prevent player leaving terrain area
-	if ( GetPlrObjectPositionX()<100 ) then SetGamePlayerControlPushangle(90.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionX()>51100 ) then SetGamePlayerControlPushangle(270.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionZ()<100 ) then SetGamePlayerControlPushangle(0.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionZ()>51100 ) then SetGamePlayerControlPushangle(180.0) SetGamePlayerControlPushforce(1.0) end
+	if allowplayertoleavemapterraineditablearea == 1 then
+	if ( GetPlrObjectPositionX() < g_mapsizeminx ) then SetGamePlayerControlPushangle(90.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionX() > g_mapsizemaxx ) then SetGamePlayerControlPushangle(270.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionZ() < g_mapsizeminz ) then SetGamePlayerControlPushangle(0.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionZ() > g_mapsizemaxz ) then SetGamePlayerControlPushangle(180.0) SetGamePlayerControlPushforce(1.0) end
+	end
 
 	-- Reduce any player push force over time
 	if ( GetGamePlayerControlPushforce()>0 ) then 


### PR DESCRIPTION
Allows for user customization of playable map area set in updated global.lua this also allows scripters to dynamically change the playable map size.

Defaults are set in the updated global.lua

Additionally, the playable map area boundaries can now be toggled by changing a local variable within the player controls.