### PR TITLE
GGC - Configurable Playable Map Area Coordinates

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
@@ -96,6 +96,12 @@ g_MouseClick = 0
 g_EntityElementMax = 0
 g_PlayerUnderwaterMode = 0
 
+-- Playable Map Size
+g_mapsizeminx = 100
+g_mapsizemaxx = 51100
+g_mapsizeminz = 100
+g_mapsizemaxz = 51100
+
 -- Checkpoint and soundloop states
 g_CheckpointX = 0
 g_CheckpointY = 0


### PR DESCRIPTION
The Playable Map Size Boundary coordinates are now set and configurable within the global.lua 

-- Default Playable Map Size Default
g_mapsizeminx = 100
g_mapsizemaxx = 51100
g_mapsizeminz = 100
g_mapsizemaxz = 51100

This update is in conjunction with the gameplayercontrol.lua update that will use these new variables: #6120

It would also resolve this issue post from 2018 #287 