### PR TITLE
GGC - New Lua Command - PlayableArea(minx,maxx,minz,maxz)

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
@@ -1,6 +1,7 @@
 -- GamePlayerControl module
 
 local gameplayercontrol = {}
+local allowplayertoleavemapterraineditablearea = 0
 
 g_gunandmeleemouseheld = 0
 g_meleekeynotfree = 0
@@ -896,10 +897,12 @@ function gameplayercontrol.control()
 	end
 
 	-- Prevent player leaving terrain area
-	if ( GetPlrObjectPositionX()<100 ) then SetGamePlayerControlPushangle(90.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionX()>51100 ) then SetGamePlayerControlPushangle(270.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionZ()<100 ) then SetGamePlayerControlPushangle(0.0) SetGamePlayerControlPushforce(1.0) end
-	if ( GetPlrObjectPositionZ()>51100 ) then SetGamePlayerControlPushangle(180.0) SetGamePlayerControlPushforce(1.0) end
+	if allowplayertoleavemapterraineditablearea == 0 then
+	if ( GetPlrObjectPositionX() < g_mapsizeminx ) then SetGamePlayerControlPushangle(90.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionX() > g_mapsizemaxx ) then SetGamePlayerControlPushangle(270.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionZ() < g_mapsizeminz ) then SetGamePlayerControlPushangle(0.0) SetGamePlayerControlPushforce(1.0) end
+	if ( GetPlrObjectPositionZ() > g_mapsizemaxz ) then SetGamePlayerControlPushangle(180.0) SetGamePlayerControlPushforce(1.0) end
+	end
 
 	-- Reduce any player push force over time
 	if ( GetGamePlayerControlPushforce()>0 ) then 

--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
@@ -96,6 +96,19 @@ g_MouseClick = 0
 g_EntityElementMax = 0
 g_PlayerUnderwaterMode = 0
 
+-- Default Playable Map Size
+g_mapsizeminx = 100
+g_mapsizemaxx = 51100
+g_mapsizeminz = 100
+g_mapsizemaxz = 51100
+
+function PlayableArea(minx,maxx,minz,maxz)
+g_mapsizeminx = minx
+g_mapsizemaxx = maxx
+g_mapsizeminz = minz
+g_mapsizemaxz = maxz
+end
+
 -- Checkpoint and soundloop states
 g_CheckpointX = 0
 g_CheckpointY = 0


### PR DESCRIPTION
The playable map area is now dynamically customizable with this new command:

**PlayableArea( minx, maxx , minz ,maxz )**

-- Default Playable Map Size set in global.lua
g_mapsizeminx = 100
g_mapsizemaxx = 51100
g_mapsizeminz = 100
g_mapsizemaxz = 51100

This will allow for creating smaller playable areas (smaller levels) or even larger playable areas that go beyond the editable terrain  area (more ideal for space games).

If you know a bit of scripting you could technically even make the playable area change size dynamically based on different factors like completing quests or reaching different objects etc to be able to explore the wider map.

Another advantage of why you might want to change your playablearea to a smaller box, is say you have an island and you dont want the player to be able swim too far. Many possibilities! 

Additionally you can use allowplayertoleavemapterraineditablearea == 1 in gameplayercontrol.lua to disable boundaries all together for endless exploring. Also better for space games.

This feature will also resolve this issue post from 2018 #6120 